### PR TITLE
Allow spawning multiple jobs over the same connection.

### DIFF
--- a/src/gearman_connection.erl
+++ b/src/gearman_connection.erl
@@ -53,12 +53,12 @@ handle_call({send_command, Packet}, _From, State) ->
         ok ->
             {reply, ok, State};
         Any ->
-            io:format("gen_tcp:send returned unhandled value ~p~n", [Any]),
+            lager:error("~p gen_tcp:send returned unhandled value ~p", [?MODULE, Any]),
             NewState = disconnect_state(State),
             {reply, {error, Any}, NewState, ?RECONNECT_DELAY}
     catch
         Exc1:Exc2 ->
-            io:format("gen_tcp:send raised an exception ~p:~p~n", [Exc1, Exc2]),
+            lager:error("~p gen_tcp:send raised an exception ~p:~p", [?MODULE, Exc1, Exc2]),
             NewState = disconnect_state(State),
             {reply, {error, {Exc1, Exc2}}, NewState, ?RECONNECT_DELAY}
     end.
@@ -77,7 +77,7 @@ handle_info(timeout, #state{host=Host, port=Port, socket=OldSocket} = State) ->
 					{noreply, State, ?RECONNECT_DELAY}
             end;
         _ ->
-            io:format("Timeout while socket not disconnected: ~p~n", [State]),
+            lager:error("~p Timeout while socket not disconnected: ~p", [?MODULE, State]),
             {noreply, State}
     end;
 handle_info({tcp, _Socket, NewData}, State) ->
@@ -87,11 +87,11 @@ handle_info({tcp_closed, _Socket}, State) ->
     NewState = disconnect_state(State),
     {noreply, NewState, ?RECONNECT_DELAY};
 handle_info(Info,  State) ->
-    io:format("UNHANDLED handle_info ~p ~p~n", [Info, State]),
+    lager:error("~p unhandled handle_info ~p ~p", [?MODULE, Info, State]),
     {noreply, State}.
 
 terminate(Reason, #state{socket=Socket}) ->
-    io:format("~p stopping: ~p~n", [?MODULE, Reason]),
+    lager:error("~p stopping: ~p", [?MODULE, Reason]),
     case Socket of
         not_connected ->
             void;

--- a/src/gearman_connection.erl
+++ b/src/gearman_connection.erl
@@ -53,12 +53,12 @@ handle_call({send_command, Packet}, _From, State) ->
         ok ->
             {reply, ok, State};
         Any ->
-            lager:error("~p gen_tcp:send returned unhandled value ~p", [?MODULE, Any]),
+            lager:error("gen_tcp:send returned unhandled value ~p", [Any]),
             NewState = disconnect_state(State),
             {reply, {error, Any}, NewState, ?RECONNECT_DELAY}
     catch
         Exc1:Exc2 ->
-            lager:error("~p gen_tcp:send raised an exception ~p:~p", [?MODULE, Exc1, Exc2]),
+            lager:error("gen_tcp:send raised an exception ~p:~p", [Exc1, Exc2]),
             NewState = disconnect_state(State),
             {reply, {error, {Exc1, Exc2}}, NewState, ?RECONNECT_DELAY}
     end.
@@ -77,7 +77,7 @@ handle_info(timeout, #state{host=Host, port=Port, socket=OldSocket} = State) ->
 					{noreply, State, ?RECONNECT_DELAY}
             end;
         _ ->
-            lager:error("~p Timeout while socket not disconnected: ~p", [?MODULE, State]),
+            lager:error("Timeout while socket not disconnected: ~p", [State]),
             {noreply, State}
     end;
 handle_info({tcp, _Socket, NewData}, State) ->
@@ -87,11 +87,11 @@ handle_info({tcp_closed, _Socket}, State) ->
     NewState = disconnect_state(State),
     {noreply, NewState, ?RECONNECT_DELAY};
 handle_info(Info,  State) ->
-    lager:error("~p unhandled handle_info ~p ~p", [?MODULE, Info, State]),
+    lager:error("unhandled handle_info ~p ~p", [Info, State]),
     {noreply, State}.
 
 terminate(Reason, #state{socket=Socket}) ->
-    lager:error("~p stopping: ~p", [?MODULE, Reason]),
+    lager:error("stopping: ~p", [Reason]),
     case Socket of
         not_connected ->
             void;

--- a/src/gearman_worker.erl
+++ b/src/gearman_worker.erl
@@ -53,15 +53,15 @@ handle_info(Other, StateName, State) ->
     ?MODULE:StateName(Other, State).
 
 handle_event(Event, StateName, State) ->
-    lager:info("~p unhandled event: ~p state: ~p", [?MODULE, Event, StateName]),
+    lager:error("unhandled event: ~p state: ~p", [Event, StateName]),
     {stop, {StateName, undefined_event, Event}, State}.
 
 handle_sync_event(Event, From, StateName, State) ->
-    lager:info("~p unheandled sync_event event: ~p from: ~p state: ~p", [?MODULE, Event, From, StateName]),
+    lager:error("unheandled sync_event event: ~p from: ~p state: ~p", [Event, From, StateName]),
     {stop, {StateName, undefined_event, Event}, State}.
 
 terminate(Reason, StateName, _State) ->
-    lager:info("~p:terminate reason: ~p state: ~p", [?MODULE, Reason, StateName]),
+    lager:info("terminate with reason: ~p state: ~p", [Reason, StateName]),
     wait_for_childrens(self(), 2000).
 
 code_change(_OldSvn, StateName, State, _Extra) ->
@@ -100,7 +100,7 @@ sleeping({Connection, command, noop}, #state{connection=Connection} = State) ->
     {next_state, working, State}.
 
 dead(Event, State) ->
-    lager:info("~p Received unexpected event for state 'dead': ~p", [?MODULE, Event]),
+    lager:info("Received unexpected event for state 'dead': ~p", [Event]),
     {next_state, dead, State}.
 
 %%%
@@ -125,7 +125,7 @@ register_functions(Connection, [{Name, _Function}|Functions]) ->
 wait_for_childrens(Pid, Timeout) ->
     {links, LinkedProcesses} = process_info(Pid, links),
     NumberChildrens = length(LinkedProcesses) -1,
-    lager:info("~p:wait_for_childrens count: ~p",[?MODULE, NumberChildrens]),
+    lager:info("wait_for_childrens count: ~p",[NumberChildrens]),
 
     if
         NumberChildrens > 0 ->

--- a/src/gearman_worker.erl
+++ b/src/gearman_worker.erl
@@ -37,10 +37,10 @@ get_functions([Module|Modules], Functions) ->
 
 %% Private Callbacks
 
-handle_info({'EXIT', _Pid, shutdown = Reason}, StateName, StateData) ->
+handle_info({'EXIT', _Pid, shutdown = Reason}, _StateName, StateData) ->
     {stop, Reason, StateData};
 
-handle_info({'EXIT', _Pid, Reason}, StateName, StateData) ->
+handle_info({'EXIT', _Pid, _Reason}, StateName, StateData) ->
     {next_state, StateName, StateData};
 
 handle_info({Connection, connected}, _StateName, #state{connection=Connection} = State) ->
@@ -53,15 +53,15 @@ handle_info(Other, StateName, State) ->
     ?MODULE:StateName(Other, State).
 
 handle_event(Event, StateName, State) ->
-    lager:info("~p unhandled event: ~p state: ~p data:~p", [?MODULE, Event, StateName, State]),
+    lager:info("~p unhandled event: ~p state: ~p", [?MODULE, Event, StateName]),
     {stop, {StateName, undefined_event, Event}, State}.
 
 handle_sync_event(Event, From, StateName, State) ->
-    lager:info("~p unheandled sync_event event: ~p from: ~p state: ~p data: ~p", [?MODULE, Event, From, StateName, State]),
+    lager:info("~p unheandled sync_event event: ~p from: ~p state: ~p", [?MODULE, Event, From, StateName]),
     {stop, {StateName, undefined_event, Event}, State}.
 
-terminate(Reason, StateName, State) ->
-    lager:info("~p:terminate reason: ~p state: ~p data: ~p", [?MODULE, Reason, StateName, State]),
+terminate(Reason, StateName, _State) ->
+    lager:info("~p:terminate reason: ~p state: ~p", [?MODULE, Reason, StateName]),
     wait_for_childrens(self(), 2000).
 
 code_change(_OldSvn, StateName, State, _Extra) ->
@@ -100,7 +100,7 @@ sleeping({Connection, command, noop}, #state{connection=Connection} = State) ->
     {next_state, working, State}.
 
 dead(Event, State) ->
-    lager:info("~p Received unexpected event for state 'dead': ~p ~p", [?MODULE, Event, State]),
+    lager:info("~p Received unexpected event for state 'dead': ~p", [?MODULE, Event]),
     {next_state, dead, State}.
 
 %%%


### PR DESCRIPTION
Without spawning the jobs you are not able to run multiple jobs over the same connection in the same time. All of them are sequential executed which is bad. 
